### PR TITLE
docs: remove unrecognized iam service action

### DIFF
--- a/doc_source/gettingstarted-prereqs.md
+++ b/doc_source/gettingstarted-prereqs.md
@@ -52,7 +52,6 @@ To use Resource Groups and Tag Editor, the following permissions must be added t
 + `tag:UntagResources`
 + `tag:getTagKeys`
 + `tag:getTagValues`
-+ `resource-explorer:List*`
 
 To use Resource Groups and Tag Editor in the console, you also need permission to run the `resource-groups:ListGroupResources` action\. This permission is necessary for listing available resource types in the current Region\. Using policy conditions with `resource-groups:ListGroupResources` is not currently supported\.
 
@@ -89,8 +88,7 @@ To add a policy for using AWS Resource Groups and Tag Editor to a user, do the f
            "tag:TagResources",
            "tag:UntagResources",
            "tag:getTagKeys",
-           "tag:getTagValues",
-           "resource-explorer:List*"
+           "tag:getTagValues"
          ],
          "Resource": "*"
        }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing `resource-explorer:List*` iam action from example Resource Groups and Tag Editor policies as it is an unrecognized service action.

Creating the example policy provided in current docs reveals the unrecognized service:

### Example Policy
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "resource-groups:*",
        "cloudformation:DescribeStacks",
        "cloudformation:ListStackResources",
        "tag:GetResources",
        "tag:TagResources",
        "tag:UntagResources",
        "tag:getTagKeys",
        "tag:getTagValues",
        "resource-explorer:List*"
      ],
      "Resource": "*"
    }
  ]
}
```

### Console: Review policy
![iam_unrecognized_action](https://user-images.githubusercontent.com/48760600/73397380-08a29380-42a9-11ea-860b-a50a8a467fb0.png)
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
